### PR TITLE
Add timeperiod id parameter to Forecast Repair

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,25 @@ Corrects common issues with Email Addresses.
 
 ##Issues Addressed
 * Bug [75588](https://web.sugarcrm.com/support/issues/75588) - Any Bean that has at least one email address, and no primary designation will get the oldest email address updated to be the primary.
+
+
+
+#:wrench: Forecast Worksheet Repairs
+Corrects common issues with Forecast Worksheets by rolling through the user "reports_to" hierarchy and re-commits forecasts in the proper order.
+
+##Parameters
+* timeperiod_id -- Required
+  * Provide the specific timeperiod id to run the commit on
+  * ALL can be passed to run for all timeperiods
+
+##Testing Command
+`cd "modules/supp_SugarRepairs/" && php cli.php --repair forecasts --timeperiod_id fd480109-081e-3c71-0941-56f032288e4f`
+
+##Execute Command
+`cd "modules/supp_SugarRepairs/" && php cli.php --repair forecasts --timeperiod_id fd480109-081e-3c71-0941-56f032288e4f --test false`
+
+##Issues Addressed
+* Bug [75779](https://web.sugarcrm.com/support/issues/75779) - Forecast worksheets totals are not accurate after making hierarchy changes.
     
 #Contributing
 Everyone is welcome to be involved by creating or improving existing Sugar repairs. If you would like to contribute, please make sure to review the [CONTRIBUTOR TERMS](CONTRIBUTOR TERMS.pdf). When you update this [README](README.md), please check out the [contribution guidelines](CONTRIBUTING.md) for helpful hints and tips that will make it easier to accept your pull request.

--- a/SugarModules/modules/supp_SugarRepairs/Classes/Repairs/supp_ForecastWorksheetRepairs.php
+++ b/SugarModules/modules/supp_SugarRepairs/Classes/Repairs/supp_ForecastWorksheetRepairs.php
@@ -7,6 +7,7 @@ class supp_ForecastWorksheetRepairs extends supp_Repairs
     protected $loggerTitle = "Forecasts";
 
     public $usersToProcess = array();
+    public $timePeriodIdsToProcess = array();
 
     function __construct()
     {
@@ -34,6 +35,30 @@ class supp_ForecastWorksheetRepairs extends supp_Repairs
             $timePeriodIds[] = $row['id'];
         }
         return $timePeriodIds;
+    }
+
+    /**
+     * Validates timeperiod_id param
+     * @return boolean
+     */
+    public function validateTimePeriodId($timeperiod_id){
+
+        $query = new SugarQuery();
+        $query->select(array(
+            'id',
+        ));
+        $query->from(BeanFactory::newBean("TimePeriods"));
+        $query->where()
+            ->equals('deleted', '0')
+            ->equals('id', $timeperiod_id);
+        
+        $returnId = $query->getOne();
+
+        if($returnId == $timeperiod_id) {
+            return true;
+        } else {
+            return false;
+        }
     }
 
     /**
@@ -205,8 +230,9 @@ class supp_ForecastWorksheetRepairs extends supp_Repairs
 
     /**
      * Executes the forecast repairs
+     * @param string $timeperiod_id Time period to re-commit
      */
-    public function repairForecastWorksheets()
+    public function repairForecastWorksheets($timeperiod_id)
     {
         $this->log('Begin forecast worksheet repairs');
 
@@ -218,11 +244,24 @@ class supp_ForecastWorksheetRepairs extends supp_Repairs
 
         krsort($this->usersToProcess);
 
-        $this->timePeriodIdsToProcess = $this->getAllTimePeriodIds();
-        foreach ($this->timePeriodIdsToProcess as $timePeriod) {
-            $this->log("-> Processing timeperiod id $timePeriod");
-            $results = $this->clearForecastWorksheet($timePeriod);
-            $this->processUserCommits($timePeriod);
+        if($timeperiod_id == "ALL") {
+            $this->timePeriodIdsToProcess = $this->getAllTimePeriodIds();
+        } else {
+            if($this->validateTimePeriodId($timeperiod_id)){
+                $this->timePeriodIdsToProcess = array($timeperiod_id);    
+            }else{
+                $this->logAction("-> Unable to find timeperiod_id '{$timeperiod_id}'. This will have to be fixed manually.");
+            }
+        }
+
+        if(is_array($this->timePeriodIdsToProcess) && count($this->timePeriodIdsToProcess) > 0) {
+            foreach ($this->timePeriodIdsToProcess as $timePeriod) {
+                $this->log("-> Processing timeperiod id $timePeriod");
+                $results = $this->clearForecastWorksheet($timePeriod);
+                $this->processUserCommits($timePeriod);
+            }
+        } else {
+            $this->log('-> No valid timeperiods found.');    
         }
         
         $this->log('End forecast worksheet repairs');
@@ -240,7 +279,7 @@ class supp_ForecastWorksheetRepairs extends supp_Repairs
         $stamp = time();
 
         if ($this->backupTable('forecast_manager_worksheets', $stamp)) {
-            $this->repairForecastWorksheets();
+            $this->repairForecastWorksheets($args['timeperiod_id']);
         } else {
             $this->log('Could not backup table');
         }

--- a/SugarModules/modules/supp_SugarRepairs/cli.php
+++ b/SugarModules/modules/supp_SugarRepairs/cli.php
@@ -23,8 +23,10 @@ if (empty($current_user) || empty($current_user->id)) {
 
 $sugarRepairs = BeanFactory::newBean('supp_SugarRepairs');
 
+$longopts = array("repair:", "test::");
+
 if (!isset($options)) {
-    $options = getopt('', array("repair:", "test::"));
+    $options = getopt('', $longopts);
 }
 
 if (isset($options['repair'])) {
@@ -43,7 +45,13 @@ if (isset($options['repair'])) {
     } else if ($options['repair'] == 'processAuthor') {
         $sugarRepairs->repairProcessAuthor($options);
     } else if ($options['repair'] == 'forecasts') {
-        $sugarRepairs->repairForecasts($options);
+        $longopts[] = "timeperiod_id:";
+        $options = getopt('', $longopts);
+        if (isset($options['timeperiod_id'])) {
+            $sugarRepairs->repairForecasts($options);
+        } else {
+            echo "Please specify the timeperiod_id parameter.\n";
+        }
     } else {
         echo "Invalid repair type. Please refer to the documentation.\n";
     }

--- a/copy/custom/tests/modules/supp_SugarRepairs/ForecastRepairsTest.php
+++ b/copy/custom/tests/modules/supp_SugarRepairs/ForecastRepairsTest.php
@@ -32,6 +32,13 @@ class suppSugarRepairsForecastWorksheetRepairsTest extends Sugar_PHPUnit_Framewo
         $bean->reports_to_id = '38c90c70-7788-13a2-668d-513e2b8df5e1';
         $bean->save();
 
+        $bean = BeanFactory::newBean("TimePeriods");
+        $bean->id = '736d000c-f79d-11e5-9b16-a19e342a368f';
+        $bean->start_date = '2015-01-01';
+        $bean->end_date = '2015-03-01';
+        $bean->new_with_id = true;
+        $bean->save();
+
         $sql_setup[] = "CREATE TABLE forecast_manager_worksheets_repairTemp LIKE forecast_manager_worksheets;";
         $sql_setup[] = "INSERT forecast_manager_worksheets_repairTemp SELECT * FROM forecast_manager_worksheets;";
         $sql_setup[] = "DELETE FROM forecast_manager_worksheets;";
@@ -58,9 +65,16 @@ class suppSugarRepairsForecastWorksheetRepairsTest extends Sugar_PHPUnit_Framewo
             )
         ";
 
-        // $sql_teardown[] = "DELETE FROM forecast_manager_worksheets;";
-        // $sql_teardown[] = "INSERT forecast_manager_worksheets SELECT * FROM forecast_manager_worksheets_repairTemp;";
-        // $sql_teardown[] = "DROP TABLE forecast_manager_worksheets_repairTemp;";
+        $sql_teardown[] = "
+            DELETE FROM timeperiods
+            WHERE id in (
+                '736d000c-f79d-11e5-9b16-a19e342a368f'
+            )
+        ";
+
+        $sql_teardown[] = "DELETE FROM forecast_manager_worksheets;";
+        $sql_teardown[] = "INSERT forecast_manager_worksheets SELECT * FROM forecast_manager_worksheets_repairTemp;";
+        $sql_teardown[] = "DROP TABLE forecast_manager_worksheets_repairTemp;";
 
         foreach ($sql_teardown as $q_teardown) {
             $res = $GLOBALS['db']->query($q_teardown);
@@ -79,6 +93,22 @@ class suppSugarRepairsForecastWorksheetRepairsTest extends Sugar_PHPUnit_Framewo
 
         $this->assertTrue(is_array($result));
         $this->assertGreaterThan(0,count($result));
+    }
+
+    /**
+     * Test for returning time period ids
+     * @covers supp_ForecastWorksheetRepairs::getAllTimePeriodIds
+     */
+    public function testValidateTimePeriodId()
+    {
+        $repairs = new supp_ForecastWorksheetRepairs();
+        $repairs->setTesting(false);
+        $result = $repairs->validateTimePeriodId("736d000c-f79d-11e5-9b16-a19e342a368f");
+
+        $this->assertTrue($result);
+        
+        $result = $repairs->validateTimePeriodId("fake_timeperiod_id_6468");
+        $this->assertFalse($result);
     }
 
     /**
@@ -147,7 +177,7 @@ class suppSugarRepairsForecastWorksheetRepairsTest extends Sugar_PHPUnit_Framewo
         $repairs = new supp_ForecastWorksheetRepairs();
         $repairs->setTesting(false);
 
-        $repairs->repairForecastWorksheets();
+        $repairs->repairForecastWorksheets("ALL");
 
         $sql = "
             SELECT id


### PR DESCRIPTION
- Forecast repair now requires trimeperiod_id parameter
- timeperiod_id can be passed as ALL to run for all timeperiods
- Timperiod is now validated
- Added tests for new timeperiod validate method
